### PR TITLE
[modules/puppet-php] Add ability to pin Composer version

### DIFF
--- a/manifests/composer.pp
+++ b/manifests/composer.pp
@@ -23,6 +23,9 @@
 # [*root_group*]
 #   UNIX group of the root user
 #
+# [*version*]
+#   If specified, pins Composer to a specific version
+#
 class php::composer (
   $source       = $::php::params::composer_source,
   $path         = $::php::params::composer_path,
@@ -31,8 +34,8 @@ class php::composer (
   $auto_update  = true,
   $max_age      = $::php::params::composer_max_age,
   $root_group   = $::php::params::root_group,
+  $version      = '',
 ) inherits ::php::params {
-
   if $caller_module_name != $module_name {
     warning('php::composer is private')
   }
@@ -61,6 +64,7 @@ class php::composer (
       path         => $path,
       proxy_type   => $proxy_type,
       proxy_server => $proxy_server,
+      version      => $version,
     }
   }
 }


### PR DESCRIPTION
[T259073](https://phabricator.tools.flnltd.com/T259073)
This PR enables pinning Composer to a specific version, either in hiera using `php::composer::version: x.y.z` and `include php::composer` in the Puppet code, or by specifying a version when instantiating the class in Puppet code: `Class{ 'php::composer': version => 'x.y.z' }`

If no `$version` is specified then an empty string is set which configures Composer to update normally as if no version was specified, ensuring backwards-compatibility with our existing PHP deployments.